### PR TITLE
feat: add team join race condition with db lock

### DIFF
--- a/src/main/java/com/example/todo/domain/repository/TeamReposiotry.java
+++ b/src/main/java/com/example/todo/domain/repository/TeamReposiotry.java
@@ -1,12 +1,24 @@
 package com.example.todo.domain.repository;
 
 import com.example.todo.domain.entity.TeamEntity;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface TeamReposiotry extends JpaRepository<TeamEntity, Long> {
     Page<TeamEntity> findTeamEntitiesByNameAndAndDeletedAtEmpty(String keyword, Pageable pageable);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select t " +
+            "from TeamEntity t " +
+            "where t.id =:teamId")
+    Optional<TeamEntity> findByIdWithPessimisticLock(@Param("teamId") Long teamId);
 }

--- a/src/main/java/com/example/todo/service/team/TeamService.java
+++ b/src/main/java/com/example/todo/service/team/TeamService.java
@@ -42,12 +42,12 @@ public class TeamService {
     public void createTeam(Long userId, TeamCreateDto teamCreateDto) {
         User manager = userRepository.findById(userId).orElseThrow(() -> new TodoAppException(ErrorCode.NOT_FOUND_USER));
 
-        if (teamCreateDto.getParticipantNum() > 5) {
-            UsersSubscriptionEntity usersSubscription = usersSubscriptionRepository.findByUsersAndSubscriptionStatus(manager, SubscriptionStatus.ACTIVE)
-                    .orElseThrow(() -> new TodoAppException(ErrorCode.NOT_FOUND_ACTIVE_SUBSCRIPTION));
-            if (teamCreateDto.getParticipantNum() > usersSubscription.getSubscription().getMaxMember())
-                throw new TodoAppException(ErrorCode.EXCEED_ALLOWED_TEAM_MEMBERS);
-        }
+//        if (teamCreateDto.getParticipantNum() > 5) {
+//            UsersSubscriptionEntity usersSubscription = usersSubscriptionRepository.findByUsersAndSubscriptionStatus(manager, SubscriptionStatus.ACTIVE)
+//                    .orElseThrow(() -> new TodoAppException(ErrorCode.NOT_FOUND_ACTIVE_SUBSCRIPTION));
+//            if (teamCreateDto.getParticipantNum() > usersSubscription.getSubscription().getMaxMember())
+//                throw new TodoAppException(ErrorCode.EXCEED_ALLOWED_TEAM_MEMBERS);
+//        }
 
         TeamEntity teamEntity = new TeamEntity();
         teamEntity.setName(teamCreateDto.getName());
@@ -73,6 +73,7 @@ public class TeamService {
         User user = userRepository.findById(userId).orElseThrow(() -> new TodoAppException(ErrorCode.NOT_FOUND_USER));
 
         TeamEntity team = teamReposiotry.findById(teamId).orElseThrow(() -> new TodoAppException(ErrorCode.NOT_FOUND_TEAM));
+//        TeamEntity team = teamReposiotry.findByIdWithPessimisticLock(teamId).orElseThrow(() -> new TodoAppException(ErrorCode.NOT_FOUND_TEAM));
 
         if (!team.getJoinCode().equals(teamJoinDto.getJoinCode()))
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Wrong JoinCode!");

--- a/src/test/java/com/example/todo/service/team/TeamServiceTest.java
+++ b/src/test/java/com/example/todo/service/team/TeamServiceTest.java
@@ -78,6 +78,8 @@ class TeamServiceTest {
     @DisplayName("제한된 팀 숫자에 여러명이 동시에 가입하는 테스트")
     @Test
     void joinTeamWithRaceCondition() throws InterruptedException {
+        // 현재, 100번 동시에 요청이 된다고 가정하면 Member 엔티티 size 값이 5를 넘는 현상이 발생한다.
+        // 그리고 100번이 아니고 한 30번? 정도만 하면 Team 엔티티 participantNum 컬럼 값이 5가 아니다.
         // given
         User user = createUser();
         createTeam(user.getId());
@@ -108,11 +110,12 @@ class TeamServiceTest {
         latch.await();
 
         List<TeamEntity> all = teamReposiotry.findAll();
-        List<MemberEntity> all1 = memberRepository.findAll();
-        System.out.println("all1.size() = " + all1.size());
+        List<MemberEntity> members = memberRepository.findAll();
+        System.out.println("members.size() = " + members.size());
 
         // then
-        assertThat(all.get(0).getParticipantNum()).isEqualTo(5);
+        assertThat(all.get(0).getParticipantNum()).isEqualTo(100);
+        assertThat(members.size()).isEqualTo(100);
     }
 
     private User createUser() {
@@ -126,7 +129,7 @@ class TeamServiceTest {
         TeamCreateDto createDto = TeamCreateDto.builder()
                 .name("구매팀")
                 .joinCode("참여코드")
-                .participantNum(5)
+                .participantNum(100)
                 .description("구매팀입니다.")
                 .build();
         teamService.createTeam(userId, createDto);


### PR DESCRIPTION
## 현재 추가한 것
- 팀 가입 동시성 테스트 코드 설명 추가 및 members 검증 로직 추가
- 팀 생성할 때 구독권 없으면 인원 제한 5명이였는데 이 검증 로직 잠시 삭제
- 비관적 락 적용한 Repository 코드 추가

## 이후에 추가할 것
- 현재 시스템에 더 적합한 낙관적 락 적용